### PR TITLE
Fixed destination registering when done in wrong order

### DIFF
--- a/src/main/java/com/sots/tiles/TileGenericPipe.java
+++ b/src/main/java/com/sots/tiles/TileGenericPipe.java
@@ -178,7 +178,7 @@ public class TileGenericPipe extends TileEntity implements IRoutable, IPipe, ITi
 			return ConnectionTypes.PIPE;
 		}
 		else if(tile!=null) {
-			if(world.getTileEntity(pos).hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side.getOpposite()));
+			if(world.getTileEntity(pos).hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side.getOpposite()))
 				return ConnectionTypes.BLOCK;
 		}
 		return ConnectionTypes.NONE;

--- a/src/main/java/com/sots/tiles/TileRoutedPipe.java
+++ b/src/main/java/com/sots/tiles/TileRoutedPipe.java
@@ -181,4 +181,17 @@ public class TileRoutedPipe extends TileGenericPipe implements IRoutable, IPipe,
 		return false;
 	}
 	
+	@Override
+	public void update() {
+		super.update();
+		if (this.hasNetwork && !(network.getNodeByID(this.nodeID).isDestination())) {
+			for (int i = 0; i < 6; i++) {
+				if (hasInventoryOnSide(i)) {
+					network.registerDestination(this.nodeID);
+					break;
+				}
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Fixed pipes not registering as destinations when chests were placed next to them afterwards