### PR TITLE
Unregister destinations

### DIFF
--- a/src/main/java/com/sots/routing/Network.java
+++ b/src/main/java/com/sots/routing/Network.java
@@ -49,6 +49,21 @@ public class Network {
 			LogisticsPipes2.logger.log(Level.WARN, "Tried to register destination [" + in + "] twice in network [" + name + "]");
 		}
 	}
+
+	public void unregisterDestination(UUID out) {
+		if (destinations.containsKey(out)) {
+			destinations.remove(out);
+			NetworkSimplifier.rescanNetwork(nodes, destinations, junctions);
+			getNodeByID(out).setAsDestination(false);
+			LogisticsPipes2.logger.log(Level.INFO, "Unregistered destination [" + out + "] in network [" + name + "]");
+		}
+		else {
+			LogisticsPipes2.logger.log(Level.WARN, "Tried to unregister destination [" + out + "] twice in network [" + name + "]");
+		}
+
+
+	}
+
 	
 	public UUID subscribeNode(IRoutable Pipe) {
 		UUID id = UUID.randomUUID();

--- a/src/main/java/com/sots/tiles/TileGenericPipe.java
+++ b/src/main/java/com/sots/tiles/TileGenericPipe.java
@@ -178,7 +178,7 @@ public class TileGenericPipe extends TileEntity implements IRoutable, IPipe, ITi
 			return ConnectionTypes.PIPE;
 		}
 		else if(tile!=null) {
-			if(world.getTileEntity(pos).hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side.getOpposite()));
+			if(world.getTileEntity(pos).hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side.getOpposite()))
 				return ConnectionTypes.BLOCK;
 		}
 		return ConnectionTypes.NONE;

--- a/src/main/java/com/sots/tiles/TileRoutedPipe.java
+++ b/src/main/java/com/sots/tiles/TileRoutedPipe.java
@@ -191,6 +191,14 @@ public class TileRoutedPipe extends TileGenericPipe implements IRoutable, IPipe,
 					break;
 				}
 			}
+		} else if (this.hasNetwork && (network.getNodeByID(this.nodeID).isDestination())) {
+			boolean hasInv = false;
+			for (int i = 0; i < 6; i++) {
+				if (hasInventoryOnSide(i))
+					hasInv = true;
+			}
+			if (!hasInv)
+				network.unregisterDestination(this.nodeID);
 		}
 	}
 

--- a/src/main/java/com/sots/tiles/TileRoutedPipe.java
+++ b/src/main/java/com/sots/tiles/TileRoutedPipe.java
@@ -181,4 +181,17 @@ public class TileRoutedPipe extends TileGenericPipe implements IRoutable, IPipe,
 		return false;
 	}
 	
+	@Override
+	public void update() {
+		super.update();
+		if (this.hasNetwork && !(network.getNodeByID(this.nodeID).isDestination())) {
+			for (int i = 0; i < 6; i++) {
+				if (hasInventoryOnSide(i)) {
+					network.registerDestination(this.nodeID);
+					break;
+				}
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Pipes now properly unregister as destinations when there are no more inventories next to them